### PR TITLE
Add missing rpm build requirements & C++ includes

### DIFF
--- a/rpm/harbour-sailfishconnect.spec
+++ b/rpm/harbour-sailfishconnect.spec
@@ -26,6 +26,8 @@ BuildRequires:  pkgconfig(openssl) >= 1.0.1
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
+BuildRequires:  pkgconfig(contextkit-statefs)
+BuildRequires:  pkgconfig(nemonotifications-qt5)
 BuildRequires:  desktop-file-utils
 
 %description

--- a/rpm/harbour-sailfishconnect.yaml
+++ b/rpm/harbour-sailfishconnect.yaml
@@ -26,6 +26,8 @@ PkgConfigBR:
   - Qt5Core
   - Qt5Qml
   - Qt5Quick
+  - contextkit-statefs
+  - nemonotifications-qt5
 
 # Build dependencies without a pkgconfig setup can be listed here
 # PkgBR:

--- a/src/sailfishconnect.cpp
+++ b/src/sailfishconnect.cpp
@@ -22,6 +22,9 @@
 #include <memory>
 #include <QLoggingCategory>
 #include <QQmlEngine>
+#include <QtQml>
+#include <QQuickView>
+#include <QGuiApplication>
 #include <sailfishapp.h>
 
 #include <execinfo.h>


### PR DESCRIPTION
Changes needed to get the RPM build done with a fresh clean SFOS SDK install.