### PR TITLE
install systemd service file

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -104,6 +104,9 @@ install(DIRECTORY translations
 install(FILES ${PACKAGE_NAME}.desktop
     DESTINATION share/applications
 )
+install(FILES ${PACKAGE_NAME}.service
+    DESTINATION share/${PACKAGE_NAME}
+)
 install(FILES icons/86x86/${PACKAGE_NAME}.png
     DESTINATION share/icons/hicolor/86x86/apps
 )

--- a/rpm/harbour-sailfishconnect.spec
+++ b/rpm/harbour-sailfishconnect.spec
@@ -135,5 +135,6 @@ desktop-file-install --delete-original       \
 %{_bindir}
 %{_datadir}/%{name}/qml
 %{_datadir}/%{name}/locale
+%{_datadir}/%{name}/harbour-sailfishconnect.service
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/icons/hicolor/*/apps/%{name}.png


### PR DESCRIPTION
Hi. 

I tried to build sailfish connect from source and install it on my device. It was complaining that service is not running, systemd service file was missing in the package...
```
[C] unknown:0 - Unable to register service: systemctl exited with 1: "Failed to enable unit: Unit file /usr/share/harbour-sailfishconnect/harbour-sailfishconnect.service does not exist.\n"
```

Right now, I have service running after phone restart, but still I have issues with automatic connect :-(