### PR TITLE
Self-assemble 'now playing' text.

### DIFF
--- a/app/qml/components/MprisUi.qml
+++ b/app/qml/components/MprisUi.qml
@@ -91,7 +91,7 @@ Column {
 
                     Label {
                         id: songLabel
-                        text: song ? song : ("<" + i18n("Nothing playing") + ">")
+                        text: ( title ) ? (artist ? (artist + " - " + title) : title) : ("<" + i18n("Nothing playing") + ">")
                         color: Theme.highlightColor
                         truncationMode: TruncationMode.Fade
                         textFormat: Text.PlainText

--- a/app/src/models/mprisplayersmodel.cpp
+++ b/app/src/models/mprisplayersmodel.cpp
@@ -56,8 +56,6 @@ QVariant MprisPlayersModel::data(const QModelIndex &index, int role) const
         return m_players[index.row()];
     case IsPlayingRole:
         return player->isPlaying();
-    case CurrentSongRole:
-        return player->currentSong();
     case TitleRole:
         return player->title();
     case ArtistRole:
@@ -95,7 +93,6 @@ QHash<int, QByteArray> MprisPlayersModel::roleNames() const
     roles[Player] = "player";
     roles[PlayerNameRole] = "playerName";
     roles[IsPlayingRole] = "isPlaying";
-    roles[CurrentSongRole] = "song";
     roles[TitleRole] = "title";
     roles[ArtistRole] = "artist";
     roles[AlbumRole] = "album";

--- a/app/src/models/mprisplayersmodel.h
+++ b/app/src/models/mprisplayersmodel.h
@@ -38,7 +38,6 @@ public:
         Player = Qt::UserRole,
         PlayerNameRole,
         IsPlayingRole,
-        CurrentSongRole,
         TitleRole,
         ArtistRole,
         AlbumRole,

--- a/plugins/sf_mprisremote/mprisremoteplugin.cpp
+++ b/plugins/sf_mprisremote/mprisremoteplugin.cpp
@@ -87,8 +87,6 @@ void MprisPlayer::setPosition(int value)
 
 void MprisPlayer::receivePacket(const NetworkPacket &np, AlbumArtCache *cache)
 {
-    m_currentSong =
-            np.get<QString>(QStringLiteral("nowPlaying"), m_currentSong);
     m_title =
             np.get<QString>(QStringLiteral("title"), m_title);
     m_artist =

--- a/plugins/sf_mprisremote/mprisremoteplugin.h
+++ b/plugins/sf_mprisremote/mprisremoteplugin.h
@@ -35,7 +35,6 @@ class MprisPlayer : public QObject
     Q_CLASSINFO("D-Bus Interface", "de.richardliebscher.sailfishconnect.mprisremote.player")
     Q_PROPERTY(QString name READ name CONSTANT)
     Q_PROPERTY(bool isPlaying READ isPlaying NOTIFY propertiesChanged)
-    Q_PROPERTY(QString currentSong READ currentSong NOTIFY propertiesChanged)
     Q_PROPERTY(QString title READ title NOTIFY propertiesChanged)
     Q_PROPERTY(QString artist READ artist NOTIFY propertiesChanged)
     Q_PROPERTY(QString album READ album NOTIFY propertiesChanged)
@@ -56,7 +55,6 @@ public:
 
     QString name() const { return m_player; }
     bool isPlaying() const { return m_isPlaying; }
-    QString currentSong() const { return m_currentSong; }
     QString title() const { return m_title; }
     QString artist() const { return m_artist; }
     QString album() const { return m_album; }
@@ -105,7 +103,6 @@ private:
     qint64 m_length = -1;
     qint64 m_lastPosition = -1;
     qint64 m_lastPositionTime = -1;
-    QString m_currentSong;
     QString m_title;
     QString m_artist;
     QString m_album;


### PR DESCRIPTION
This stopped working for me some time ago. Looking at data coming from a desktop KDE Connect (23.08.4), a now playing field doesn't seem to be there, and indeed, it was removed in this commit: https://github.com/KDE/kdeconnect-kde/commit/2e0550651e17062c07505c8298fce78341d336a0
