### PR TITLE
Show list headers as strings.

### DIFF
--- a/app/qml/pages/DeviceListPage.qml
+++ b/app/qml/pages/DeviceListPage.qml
@@ -217,7 +217,7 @@ Page {
                 id: sectionHeading
 
                 SectionHeader {
-                    text: section
+                    text: roleTexts(section)
                 }
             }
 
@@ -274,6 +274,20 @@ Page {
         running: true
         repeat: false
         onTriggered: startup = false
+    }
+
+    function roleTexts(section) {
+        switch(Number(section)) {
+        case DeviceListModel.Connected:
+            return i18n("Connected")
+        case DeviceListModel.Trusted:
+            return i18n("Paired devices")
+        case DeviceListModel.Near:
+            return i18n("Nearby devices")
+        case DeviceListModel.Nothing:
+        default:
+            return "-"
+        }
     }
 
     function openDevicePage(deviceId) {


### PR DESCRIPTION
Previously, only the numerical value was shown. I didn't find any existing code that would do this elsewhere, so I added it as a js function on the qml page.